### PR TITLE
Restore riemann release for riemann-emitter job.

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -50,121 +50,120 @@ director_uuid: ~
 #
 # e.g. X.X.0.2 -> 10.0.0.2
 networks:
-  - name: concourse
-    type: manual
-    subnets:
-      - range: (( grab meta.network.range ))
-        reserved: (( grab meta.network.reserved ))
-        gateway: (( grab meta.network.gateway ))
-        dns: (( grab meta.network.dns ))
-        cloud_properties:
-          security_groups: (( grab meta.network.security_groups ))
-          subnet: (( grab meta.network.subnet ))
+- name: concourse
+  type: manual
+  subnets:
+  - range: (( grab meta.network.range ))
+    reserved: (( grab meta.network.reserved ))
+    gateway: (( grab meta.network.gateway ))
+    dns: (( grab meta.network.dns ))
+    cloud_properties:
+      security_groups: (( grab meta.network.security_groups ))
+      subnet: (( grab meta.network.subnet ))
 
 releases:
-  - name: concourse
-    version: latest
-  - name: garden-runc
-    version: latest
+- {name: concourse, version: latest}
+- {name: garden-runc, version: latest}
+- {name: riemann, version: latest}
 
 instance_groups:
-  - name: web
-    instances: 1
-    resource_pool: web
-    networks: [{name: concourse}]
-    jobs:
-      - release: concourse
-        name: atc
-        properties:
-          web_bind_port: 8080
-          external_url: (( grab meta.atc.external_url ))
-          github_auth:
-            authorize: (( grab meta.atc.github_auth.authorize ))
-            client_id: (( grab meta.atc.github_auth.client_id ))
-            client_secret: (( grab meta.atc.github_auth.client_secret ))
-          postgresql:
-            address: (( grab meta.atc.db.address ))
-            database: (( grab meta.atc.db.name ))
-            role:
-              name: (( grab meta.atc.db.user ))
-              password: (( grab meta.atc.db.pass ))
-      - release: concourse
-        name: tsa
-        properties: {}
-      - release: riemann
-        name: riemann-emitter
-        properties:
-          riemann_emitter:
-            host: (( grab meta.riemann_emitter.host ))
-            port: (( grab meta.riemann_emitter.port ))
-            health: true
-            rds:
-              instance_name: (( grab meta.rds.instance_name ))
-              region: (( grab meta.rds.region ))
-              access_key_id: (( grab meta.rds.access_key_id ))
-              secret_access_key: (( grab meta.rds.secret_access_key ))
+- name: web
+  instances: 1
+  resource_pool: web
+  networks: [{name: concourse}]
+  jobs:
+  - release: concourse
+    name: atc
+    properties:
+      web_bind_port: 8080
+      external_url: (( grab meta.atc.external_url ))
+      github_auth:
+        authorize: (( grab meta.atc.github_auth.authorize ))
+        client_id: (( grab meta.atc.github_auth.client_id ))
+        client_secret: (( grab meta.atc.github_auth.client_secret ))
+      postgresql:
+        address: (( grab meta.atc.db.address ))
+        database: (( grab meta.atc.db.name ))
+        role:
+          name: (( grab meta.atc.db.user ))
+          password: (( grab meta.atc.db.pass ))
+  - release: concourse
+    name: tsa
+    properties: {}
+  - release: riemann
+    name: riemann-emitter
+    properties:
+      riemann_emitter:
+        host: (( grab meta.riemann_emitter.host ))
+        port: (( grab meta.riemann_emitter.port ))
+        health: true
+        rds:
+          instance_name: (( grab meta.rds.instance_name ))
+          region: (( grab meta.rds.region ))
+          access_key_id: (( grab meta.rds.access_key_id ))
+          secret_access_key: (( grab meta.rds.secret_access_key ))
 
-  - name: worker
-    instances: 1
-    resource_pool: workers
-    networks: [{name: concourse}]
-    jobs:
-      - release: concourse
-        name: groundcrew
-        properties:
-          additional_resource_types:
-            - type: slack-notification
-              image: docker:///cfcommunity/slack-notification-resource
-            - type: cg-common
-              image: docker:///18fgsa/cg-common-resource
-            - type: 18f-bosh-deployment
-              image: docker:///18fgsa/bosh-deployment-resource
-      - release: concourse
-        name: baggageclaim
-        properties: {}
-      - release: garden-runc
-        name: garden
-        properties:
-          garden:
-            listen_network: tcp
-            listen_address: 0.0.0.0:7777
-            enable_graph_cleanup: true
-            default_container_grace_time: 10m
-            max_containers: 250
-            network_pool: 10.254.0.0/20
-      - release: riemann
-        name: riemann-emitter
-        properties:
-          riemann_emitter:
-            host: (( grab meta.riemann_emitter.host ))
-            port: (( grab meta.riemann_emitter.port ))
-            health: true
+- name: worker
+  instances: 1
+  resource_pool: workers
+  networks: [{name: concourse}]
+  jobs:
+  - release: concourse
+    name: groundcrew
+    properties:
+      additional_resource_types:
+      - type: slack-notification
+        image: docker:///cfcommunity/slack-notification-resource
+      - type: cg-common
+        image: docker:///18fgsa/cg-common-resource
+      - type: 18f-bosh-deployment
+        image: docker:///18fgsa/bosh-deployment-resource
+  - release: concourse
+    name: baggageclaim
+    properties: {}
+  - release: garden-runc
+    name: garden
+    properties:
+      garden:
+        listen_network: tcp
+        listen_address: 0.0.0.0:7777
+        enable_graph_cleanup: true
+        default_container_grace_time: 10m
+        max_containers: 250
+        network_pool: 10.254.0.0/20
+  - release: riemann
+    name: riemann-emitter
+    properties:
+      riemann_emitter:
+        host: (( grab meta.riemann_emitter.host ))
+        port: (( grab meta.riemann_emitter.port ))
+        health: true
 
 resource_pools:
-  - name: web
-    network: concourse
-    stemcell: &stemcell
-      name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-      version: latest
-    cloud_properties:
-      availability_zone: &az (( grab meta.az ))
-      instance_type: (( grab meta.resources.web.instance_type ))
-      elbs: (( grab meta.resources.web.elbs ))
-      ephemeral_disk:
-        size: 45000
-        type: gp2
-        encrypted: true
+- name: web
+  network: concourse
+  stemcell: &stemcell
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: latest
+  cloud_properties:
+    availability_zone: &az (( grab meta.az ))
+    instance_type: (( grab meta.resources.web.instance_type ))
+    elbs: (( grab meta.resources.web.elbs ))
+    ephemeral_disk:
+      size: 45000
+      type: gp2
+      encrypted: true
 
-  - name: workers
-    network: concourse
-    stemcell: *stemcell
-    cloud_properties:
-      availability_zone: *az
-      instance_type: (( grab meta.resources.workers.instance_type ))
-      ephemeral_disk:
-        size: 300000
-        type: gp2
-        encrypted: true
+- name: workers
+  network: concourse
+  stemcell: *stemcell
+  cloud_properties:
+    availability_zone: *az
+    instance_type: (( grab meta.resources.workers.instance_type ))
+    ephemeral_disk:
+      size: 300000
+      type: gp2
+      encrypted: true
 
 compilation:
   workers: 3

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -1,4 +1,3 @@
-
 director_uuid: DIRECTOR_UUID
 
 name: concourse


### PR DESCRIPTION
The main thing happening here is restoring the `riemann` release so that we can pull in the `riemann-emitter` job--apparently including the release in the runtime config doesn't expose its jobs here. I also fixed some yaml indentatation errors, which is why the diff is more than one line.