### PR TITLE
[WIP] Use tooling cloud config.

### DIFF
--- a/concourse-production.yml
+++ b/concourse-production.yml
@@ -2,6 +2,9 @@ instance_groups:
 - name: web
   vm_type: production-concourse-web
   vm_extensions: [production-concourse-lb]
+  azs: [z1]
+  networks:
+  - name: production-concourse
   jobs:
   - name: atc
     properties:
@@ -20,3 +23,6 @@ instance_groups:
 - name: worker
   vm_type: production-concourse-worker
   vm_extensions: [production-concourse-profile]
+  azs: [z1]
+  networks:
+  - name: production-concourse

--- a/concourse-production.yml
+++ b/concourse-production.yml
@@ -1,25 +1,8 @@
-networks:
-- name: concourse
-  subnets:
-  - range: (( grab terraform_outputs.production_concourse_subnet_cidr ))
-    gateway: (( grab terraform_outputs.production_concourse_subnet_gateway ))
-    cloud_properties:
-      subnet: (( grab terraform_outputs.production_concourse_subnet ))
-      security_groups:
-      - (( grab terraform_outputs.production_concourse_security_group ))
-      - (( grab terraform_outputs.bosh_security_group ))
-
-resource_pools:
-- name: web
-  cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.production_concourse_elb_name ))
-- name: workers
-  cloud_properties:
-    iam_instance_profile: (( grab terraform_outputs.concourse_worker_profile ))
-
 instance_groups:
 - name: web
+  azs: [az1]
+  vm_type: production-concourse-web
+  vm_extensions: [production-concourse-lb]
   jobs:
   - name: atc
     properties:
@@ -82,3 +65,7 @@ instance_groups:
         rds:
           instance_name: (( grab terraform_outputs.production_concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
+- name: worker
+  azs: [az1]
+  vm_type: production-concourse-worker
+  vm_extensions: [production-concourse-profile]

--- a/concourse-production.yml
+++ b/concourse-production.yml
@@ -1,6 +1,5 @@
 instance_groups:
 - name: web
-  azs: [az1]
   vm_type: production-concourse-web
   vm_extensions: [production-concourse-lb]
   jobs:
@@ -66,6 +65,5 @@ instance_groups:
           instance_name: (( grab terraform_outputs.production_concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
 - name: worker
-  azs: [az1]
   vm_type: production-concourse-worker
   vm_extensions: [production-concourse-profile]

--- a/concourse-production.yml
+++ b/concourse-production.yml
@@ -6,53 +6,6 @@ instance_groups:
   - name: atc
     properties:
       postgresql:
-        # The following is the root and govcloud intermediate certs found
-        # at http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
-        ca_cert: |
-          -----BEGIN CERTIFICATE-----
-          MIID9DCCAtygAwIBAgIBQjANBgkqhkiG9w0BAQUFADCBijELMAkGA1UEBhMCVVMx
-          EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoM
-          GUFtYXpvbiBXZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMx
-          GzAZBgNVBAMMEkFtYXpvbiBSRFMgUm9vdCBDQTAeFw0xNTAyMDUwOTExMzFaFw0y
-          MDAzMDUwOTExMzFaMIGKMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3Rv
-          bjEQMA4GA1UEBwwHU2VhdHRsZTEiMCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNl
-          cywgSW5jLjETMBEGA1UECwwKQW1hem9uIFJEUzEbMBkGA1UEAwwSQW1hem9uIFJE
-          UyBSb290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuD8nrZ8V
-          u+VA8yVlUipCZIKPTDcOILYpUe8Tct0YeQQr0uyl018StdBsa3CjBgvwpDRq1HgF
-          Ji2N3+39+shCNspQeE6aYU+BHXhKhIIStt3r7gl/4NqYiDDMWKHxHq0nsGDFfArf
-          AOcjZdJagOMqb3fF46flc8k2E7THTm9Sz4L7RY1WdABMuurpICLFE3oHcGdapOb9
-          T53pQR+xpHW9atkcf3pf7gbO0rlKVSIoUenBlZipUlp1VZl/OD/E+TtRhDDNdI2J
-          P/DSMM3aEsq6ZQkfbz/Ilml+Lx3tJYXUDmp+ZjzMPLk/+3beT8EhrwtcG3VPpvwp
-          BIOqsqVVTvw/CwIDAQABo2MwYTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUw
-          AwEB/zAdBgNVHQ4EFgQUTgLurD72FchM7Sz1BcGPnIQISYMwHwYDVR0jBBgwFoAU
-          TgLurD72FchM7Sz1BcGPnIQISYMwDQYJKoZIhvcNAQEFBQADggEBAHZcgIio8pAm
-          MjHD5cl6wKjXxScXKtXygWH2BoDMYBJF9yfyKO2jEFxYKbHePpnXB1R04zJSWAw5
-          2EUuDI1pSBh9BA82/5PkuNlNeSTB3dXDD2PEPdzVWbSKvUB8ZdooV+2vngL0Zm4r
-          47QPyd18yPHrRIbtBtHR/6CwKevLZ394zgExqhnekYKIqqEX41xsUV0Gm6x4vpjf
-          2u6O/+YE2U+qyyxHE5Wd5oqde0oo9UUpFETJPVb6Q2cEeQib8PBAyi0i6KnF+kIV
-          A9dY7IHSubtCK/i8wxMVqfd5GtbA8mmpeJFwnDvm9rBEsHybl08qlax9syEwsUYr
-          /40NawZfTUU=
-          -----END CERTIFICATE-----
-          -----BEGIN CERTIFICATE-----
-          MIIDQzCCAqygAwIBAgIJAMGs6m/j+u8sMA0GCSqGSIb3DQEBBQUAMHUxCzAJBgNV
-          BAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTZWF0dGxlMRMw
-          EQYDVQQKEwpBbWF6b24uY29tMQwwCgYDVQQLEwNSRFMxHDAaBgNVBAMTE2F3cy5h
-          bWF6b24uY29tL3Jkcy8wHhcNMTIwODE2MDY0MjAwWhcNMTcwODE1MDY0MjAwWjB1
-          MQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2Vh
-          dHRsZTETMBEGA1UEChMKQW1hem9uLmNvbTEMMAoGA1UECxMDUkRTMRwwGgYDVQQD
-          ExNhd3MuYW1hem9uLmNvbS9yZHMvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
-          gQCnTB7AkRR4xuhfAuOt5foNeCRBPeUujkzmJu1yfnTbtFi+g7zmovQ9BJcRoPYL
-          45McnXyaT/7UjhJhCI5gnYlTIyBTRFh7lXFJryypFx8AIh6q3D/ht8b6cVro3sJ2
-          k4x1w/c7akKKsZJtf0ZyhbMvNnBz3K3TWVB6c9DChbfyUQIDAQABo4HaMIHXMB0G
-          A1UdDgQWBBS/OwyfNJHDnAmnZBbq9ACiXz7O1jCBpwYDVR0jBIGfMIGcgBS/Owyf
-          NJHDnAmnZBbq9ACiXz7O1qF5pHcwdTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldh
-          c2hpbmd0b24xEDAOBgNVBAcTB1NlYXR0bGUxEzARBgNVBAoTCkFtYXpvbi5jb20x
-          DDAKBgNVBAsTA1JEUzEcMBoGA1UEAxMTYXdzLmFtYXpvbi5jb20vcmRzL4IJAMGs
-          6m/j+u8sMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEACR37LqHlzjSH
-          9gHCaiVJgCb0CCxSg3PHaQuv8h4ugAqQpGxpX3Zo97VgHnjEve21gXA74kzGUUAo
-          7YNTZWbF2VkHUDqekXimvL3q1JEvHDKPkLJrxEic1zTU1uazb9uJeb1aVWTq6N8R
-          bx56xd/e3o7RYcPfLD45y7RRXKz3AmE=
-          -----END CERTIFICATE-----
         database: (( grab terraform_outputs.production_concourse_rds_name ))
         host: (( grab terraform_outputs.production_concourse_rds_host ))
         role:

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -1,6 +1,5 @@
 instance_groups:
 - name: web
-  azs: [az1]
   vm_type: staging-concourse-web
   vm_extensions: [staging-concourse-lb]
   jobs:
@@ -66,6 +65,5 @@ instance_groups:
           instance_name: (( grab terraform_outputs.staging_concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
 - name: worker
-  azs: [az1]
   vm_type: staging-concourse-worker
   vm_extensions: [staging-concourse-profile]

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -2,6 +2,9 @@ instance_groups:
 - name: web
   vm_type: staging-concourse-web
   vm_extensions: [staging-concourse-lb]
+  azs: [z2]
+  networks:
+  - name: staging-concourse
   jobs:
   - name: atc
     properties:
@@ -20,3 +23,6 @@ instance_groups:
 - name: worker
   vm_type: staging-concourse-worker
   vm_extensions: [staging-concourse-profile]
+  azs: [z2]
+  networks:
+  - name: staging-concourse

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -6,53 +6,6 @@ instance_groups:
   - name: atc
     properties:
       postgresql:
-        # The following is the root and govcloud intermediate certs found
-        # at http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
-        ca_cert: |
-          -----BEGIN CERTIFICATE-----
-          MIID9DCCAtygAwIBAgIBQjANBgkqhkiG9w0BAQUFADCBijELMAkGA1UEBhMCVVMx
-          EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoM
-          GUFtYXpvbiBXZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMx
-          GzAZBgNVBAMMEkFtYXpvbiBSRFMgUm9vdCBDQTAeFw0xNTAyMDUwOTExMzFaFw0y
-          MDAzMDUwOTExMzFaMIGKMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3Rv
-          bjEQMA4GA1UEBwwHU2VhdHRsZTEiMCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNl
-          cywgSW5jLjETMBEGA1UECwwKQW1hem9uIFJEUzEbMBkGA1UEAwwSQW1hem9uIFJE
-          UyBSb290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuD8nrZ8V
-          u+VA8yVlUipCZIKPTDcOILYpUe8Tct0YeQQr0uyl018StdBsa3CjBgvwpDRq1HgF
-          Ji2N3+39+shCNspQeE6aYU+BHXhKhIIStt3r7gl/4NqYiDDMWKHxHq0nsGDFfArf
-          AOcjZdJagOMqb3fF46flc8k2E7THTm9Sz4L7RY1WdABMuurpICLFE3oHcGdapOb9
-          T53pQR+xpHW9atkcf3pf7gbO0rlKVSIoUenBlZipUlp1VZl/OD/E+TtRhDDNdI2J
-          P/DSMM3aEsq6ZQkfbz/Ilml+Lx3tJYXUDmp+ZjzMPLk/+3beT8EhrwtcG3VPpvwp
-          BIOqsqVVTvw/CwIDAQABo2MwYTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUw
-          AwEB/zAdBgNVHQ4EFgQUTgLurD72FchM7Sz1BcGPnIQISYMwHwYDVR0jBBgwFoAU
-          TgLurD72FchM7Sz1BcGPnIQISYMwDQYJKoZIhvcNAQEFBQADggEBAHZcgIio8pAm
-          MjHD5cl6wKjXxScXKtXygWH2BoDMYBJF9yfyKO2jEFxYKbHePpnXB1R04zJSWAw5
-          2EUuDI1pSBh9BA82/5PkuNlNeSTB3dXDD2PEPdzVWbSKvUB8ZdooV+2vngL0Zm4r
-          47QPyd18yPHrRIbtBtHR/6CwKevLZ394zgExqhnekYKIqqEX41xsUV0Gm6x4vpjf
-          2u6O/+YE2U+qyyxHE5Wd5oqde0oo9UUpFETJPVb6Q2cEeQib8PBAyi0i6KnF+kIV
-          A9dY7IHSubtCK/i8wxMVqfd5GtbA8mmpeJFwnDvm9rBEsHybl08qlax9syEwsUYr
-          /40NawZfTUU=
-          -----END CERTIFICATE-----
-          -----BEGIN CERTIFICATE-----
-          MIIDQzCCAqygAwIBAgIJAMGs6m/j+u8sMA0GCSqGSIb3DQEBBQUAMHUxCzAJBgNV
-          BAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTZWF0dGxlMRMw
-          EQYDVQQKEwpBbWF6b24uY29tMQwwCgYDVQQLEwNSRFMxHDAaBgNVBAMTE2F3cy5h
-          bWF6b24uY29tL3Jkcy8wHhcNMTIwODE2MDY0MjAwWhcNMTcwODE1MDY0MjAwWjB1
-          MQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2Vh
-          dHRsZTETMBEGA1UEChMKQW1hem9uLmNvbTEMMAoGA1UECxMDUkRTMRwwGgYDVQQD
-          ExNhd3MuYW1hem9uLmNvbS9yZHMvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
-          gQCnTB7AkRR4xuhfAuOt5foNeCRBPeUujkzmJu1yfnTbtFi+g7zmovQ9BJcRoPYL
-          45McnXyaT/7UjhJhCI5gnYlTIyBTRFh7lXFJryypFx8AIh6q3D/ht8b6cVro3sJ2
-          k4x1w/c7akKKsZJtf0ZyhbMvNnBz3K3TWVB6c9DChbfyUQIDAQABo4HaMIHXMB0G
-          A1UdDgQWBBS/OwyfNJHDnAmnZBbq9ACiXz7O1jCBpwYDVR0jBIGfMIGcgBS/Owyf
-          NJHDnAmnZBbq9ACiXz7O1qF5pHcwdTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldh
-          c2hpbmd0b24xEDAOBgNVBAcTB1NlYXR0bGUxEzARBgNVBAoTCkFtYXpvbi5jb20x
-          DDAKBgNVBAsTA1JEUzEcMBoGA1UEAxMTYXdzLmFtYXpvbi5jb20vcmRzL4IJAMGs
-          6m/j+u8sMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEACR37LqHlzjSH
-          9gHCaiVJgCb0CCxSg3PHaQuv8h4ugAqQpGxpX3Zo97VgHnjEve21gXA74kzGUUAo
-          7YNTZWbF2VkHUDqekXimvL3q1JEvHDKPkLJrxEic1zTU1uazb9uJeb1aVWTq6N8R
-          bx56xd/e3o7RYcPfLD45y7RRXKz3AmE=
-          -----END CERTIFICATE-----
         database: (( grab terraform_outputs.staging_concourse_rds_name ))
         host: (( grab terraform_outputs.staging_concourse_rds_host ))
         role:

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -1,25 +1,8 @@
-networks:
-- name: concourse
-  subnets:
-  - range: (( grab terraform_outputs.staging_concourse_subnet_cidr ))
-    gateway: (( grab terraform_outputs.staging_concourse_subnet_gateway ))
-    cloud_properties:
-      subnet: (( grab terraform_outputs.staging_concourse_subnet ))
-      security_groups:
-      - (( grab terraform_outputs.staging_concourse_security_group ))
-      - (( grab terraform_outputs.bosh_security_group ))
-
-resource_pools:
-- name: web
-  cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.staging_concourse_elb_name ))
-- name: workers
-  cloud_properties:
-    iam_instance_profile: (( grab terraform_outputs.concourse_worker_profile ))
-
 instance_groups:
 - name: web
+  azs: [az1]
+  vm_type: staging-concourse-web
+  vm_extensions: [staging-concourse-lb]
   jobs:
   - name: atc
     properties:
@@ -82,3 +65,7 @@ instance_groups:
         rds:
           instance_name: (( grab terraform_outputs.staging_concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
+- name: worker
+  azs: [az1]
+  vm_type: staging-concourse-worker
+  vm_extensions: [staging-concourse-profile]

--- a/concourse-tenant.yml
+++ b/concourse-tenant.yml
@@ -1,8 +1,10 @@
 instance_groups:
 - name: web
-  resource_pool: web
   vm_type: concourse-web
   vm_extensions: [concourse-lb]
+  azs: [z2]
+  networks:
+  - name: concourse
   jobs:
   - name: atc
     properties:
@@ -20,3 +22,6 @@ instance_groups:
           region: (( grab meta.rds.region ))
 - name: worker
   vm_type: concourse-worker
+  azs: [z2]
+  networks:
+  - name: concourse

--- a/concourse-tenant.yml
+++ b/concourse-tenant.yml
@@ -7,53 +7,6 @@ instance_groups:
   - name: atc
     properties:
       postgresql:
-        # The following is the root and govcloud intermediate certs found
-        # at http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
-        ca_cert: |
-          -----BEGIN CERTIFICATE-----
-          MIID9DCCAtygAwIBAgIBQjANBgkqhkiG9w0BAQUFADCBijELMAkGA1UEBhMCVVMx
-          EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoM
-          GUFtYXpvbiBXZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMx
-          GzAZBgNVBAMMEkFtYXpvbiBSRFMgUm9vdCBDQTAeFw0xNTAyMDUwOTExMzFaFw0y
-          MDAzMDUwOTExMzFaMIGKMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3Rv
-          bjEQMA4GA1UEBwwHU2VhdHRsZTEiMCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNl
-          cywgSW5jLjETMBEGA1UECwwKQW1hem9uIFJEUzEbMBkGA1UEAwwSQW1hem9uIFJE
-          UyBSb290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuD8nrZ8V
-          u+VA8yVlUipCZIKPTDcOILYpUe8Tct0YeQQr0uyl018StdBsa3CjBgvwpDRq1HgF
-          Ji2N3+39+shCNspQeE6aYU+BHXhKhIIStt3r7gl/4NqYiDDMWKHxHq0nsGDFfArf
-          AOcjZdJagOMqb3fF46flc8k2E7THTm9Sz4L7RY1WdABMuurpICLFE3oHcGdapOb9
-          T53pQR+xpHW9atkcf3pf7gbO0rlKVSIoUenBlZipUlp1VZl/OD/E+TtRhDDNdI2J
-          P/DSMM3aEsq6ZQkfbz/Ilml+Lx3tJYXUDmp+ZjzMPLk/+3beT8EhrwtcG3VPpvwp
-          BIOqsqVVTvw/CwIDAQABo2MwYTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUw
-          AwEB/zAdBgNVHQ4EFgQUTgLurD72FchM7Sz1BcGPnIQISYMwHwYDVR0jBBgwFoAU
-          TgLurD72FchM7Sz1BcGPnIQISYMwDQYJKoZIhvcNAQEFBQADggEBAHZcgIio8pAm
-          MjHD5cl6wKjXxScXKtXygWH2BoDMYBJF9yfyKO2jEFxYKbHePpnXB1R04zJSWAw5
-          2EUuDI1pSBh9BA82/5PkuNlNeSTB3dXDD2PEPdzVWbSKvUB8ZdooV+2vngL0Zm4r
-          47QPyd18yPHrRIbtBtHR/6CwKevLZ394zgExqhnekYKIqqEX41xsUV0Gm6x4vpjf
-          2u6O/+YE2U+qyyxHE5Wd5oqde0oo9UUpFETJPVb6Q2cEeQib8PBAyi0i6KnF+kIV
-          A9dY7IHSubtCK/i8wxMVqfd5GtbA8mmpeJFwnDvm9rBEsHybl08qlax9syEwsUYr
-          /40NawZfTUU=
-          -----END CERTIFICATE-----
-          -----BEGIN CERTIFICATE-----
-          MIIDQzCCAqygAwIBAgIJAMGs6m/j+u8sMA0GCSqGSIb3DQEBBQUAMHUxCzAJBgNV
-          BAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTZWF0dGxlMRMw
-          EQYDVQQKEwpBbWF6b24uY29tMQwwCgYDVQQLEwNSRFMxHDAaBgNVBAMTE2F3cy5h
-          bWF6b24uY29tL3Jkcy8wHhcNMTIwODE2MDY0MjAwWhcNMTcwODE1MDY0MjAwWjB1
-          MQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2Vh
-          dHRsZTETMBEGA1UEChMKQW1hem9uLmNvbTEMMAoGA1UECxMDUkRTMRwwGgYDVQQD
-          ExNhd3MuYW1hem9uLmNvbS9yZHMvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
-          gQCnTB7AkRR4xuhfAuOt5foNeCRBPeUujkzmJu1yfnTbtFi+g7zmovQ9BJcRoPYL
-          45McnXyaT/7UjhJhCI5gnYlTIyBTRFh7lXFJryypFx8AIh6q3D/ht8b6cVro3sJ2
-          k4x1w/c7akKKsZJtf0ZyhbMvNnBz3K3TWVB6c9DChbfyUQIDAQABo4HaMIHXMB0G
-          A1UdDgQWBBS/OwyfNJHDnAmnZBbq9ACiXz7O1jCBpwYDVR0jBIGfMIGcgBS/Owyf
-          NJHDnAmnZBbq9ACiXz7O1qF5pHcwdTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldh
-          c2hpbmd0b24xEDAOBgNVBAcTB1NlYXR0bGUxEzARBgNVBAoTCkFtYXpvbi5jb20x
-          DDAKBgNVBAsTA1JEUzEcMBoGA1UEAxMTYXdzLmFtYXpvbi5jb20vcmRzL4IJAMGs
-          6m/j+u8sMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEACR37LqHlzjSH
-          9gHCaiVJgCb0CCxSg3PHaQuv8h4ugAqQpGxpX3Zo97VgHnjEve21gXA74kzGUUAo
-          7YNTZWbF2VkHUDqekXimvL3q1JEvHDKPkLJrxEic1zTU1uazb9uJeb1aVWTq6N8R
-          bx56xd/e3o7RYcPfLD45y7RRXKz3AmE=
-          -----END CERTIFICATE-----
         database: (( grab terraform_outputs.concourse_rds_name ))
         host: (( grab terraform_outputs.concourse_rds_host ))
         role:

--- a/concourse-tenant.yml
+++ b/concourse-tenant.yml
@@ -1,45 +1,8 @@
-networks:
-- name: concourse
-  type: manual
-  subnets:
-  - range: (( grab terraform_outputs.concourse_subnet_cidr ))
-    gateway: (( grab terraform_outputs.concourse_subnet_gateway ))
-    cloud_properties:
-      subnet: (( grab terraform_outputs.concourse_subnet ))
-      security_groups:
-      - (( grab terraform_outputs.concourse_security_group ))
-      - (( grab terraform_outputs.bosh_security_group ))
-
-resource_pools:
-- name: web
-  network: concourse
-  stemcell: &stemcell
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: latest
-  cloud_properties:
-    availability_zone: &az (( grab meta.az ))
-    instance_type: (( grab meta.resources.web.instance_type ))
-    elbs:
-    - (( grab terraform_outputs.concourse_elb_name ))
-    ephemeral_disk:
-      size: 45000
-      type: gp2
-      encrypted: true
-
-- name: workers
-  network: concourse
-  stemcell: *stemcell
-  cloud_properties:
-    availability_zone: *az
-    instance_type: (( grab meta.resources.workers.instance_type ))
-    ephemeral_disk:
-      size: 300000
-      type: gp2
-      encrypted: true
-
 instance_groups:
 - name: web
   resource_pool: web
+  vm_type: concourse-web
+  vm_extensions: [concourse-lb]
   jobs:
   - name: atc
     properties:
@@ -103,17 +66,4 @@ instance_groups:
           instance_name: (( grab terraform_outputs.concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
 - name: worker
-  resource_pool: worker
-
-compilation:
-  workers: 3
-  network: concourse
-  reuse_compilation_vms: true
-  cloud_properties:
-    availability_zone: *az
-    instance_type: (( grab meta.compilation.instance_type ))
-    iam_instance_profile: (( grab terraform_outputs.bosh_compilation_profile ))
-    ephemeral_disk:
-      size: (( grab meta.compilation.disk.size ))
-      type: (( grab meta.compilation.disk.type ))
-      encrypted: true
+  vm_type: concourse-worker

--- a/concourse-tenant.yml
+++ b/concourse-tenant.yml
@@ -1,5 +1,6 @@
 networks:
 - name: concourse
+  type: manual
   subnets:
   - range: (( grab terraform_outputs.concourse_subnet_cidr ))
     gateway: (( grab terraform_outputs.concourse_subnet_gateway ))
@@ -11,12 +12,34 @@ networks:
 
 resource_pools:
 - name: web
+  network: concourse
+  stemcell: &stemcell
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: latest
   cloud_properties:
+    availability_zone: &az (( grab meta.az ))
+    instance_type: (( grab meta.resources.web.instance_type ))
     elbs:
     - (( grab terraform_outputs.concourse_elb_name ))
+    ephemeral_disk:
+      size: 45000
+      type: gp2
+      encrypted: true
+
+- name: workers
+  network: concourse
+  stemcell: *stemcell
+  cloud_properties:
+    availability_zone: *az
+    instance_type: (( grab meta.resources.workers.instance_type ))
+    ephemeral_disk:
+      size: 300000
+      type: gp2
+      encrypted: true
 
 instance_groups:
 - name: web
+  resource_pool: web
   jobs:
   - name: atc
     properties:
@@ -79,3 +102,18 @@ instance_groups:
         rds:
           instance_name: (( grab terraform_outputs.concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
+- name: worker
+  resource_pool: worker
+
+compilation:
+  workers: 3
+  network: concourse
+  reuse_compilation_vms: true
+  cloud_properties:
+    availability_zone: *az
+    instance_type: (( grab meta.compilation.instance_type ))
+    iam_instance_profile: (( grab terraform_outputs.bosh_compilation_profile ))
+    ephemeral_disk:
+      size: (( grab meta.compilation.disk.size ))
+      type: (( grab meta.compilation.disk.type ))
+      encrypted: true

--- a/concourse.yml
+++ b/concourse.yml
@@ -20,12 +20,15 @@ releases:
 - {name: garden-runc, version: latest}
 - {name: riemann, version: latest}
 
+stemcells:
+- alias: default
+  name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+  version: latest
+
 instance_groups:
 - name: web
   instances: 1
-  azs: [az1]
-  networks:
-  - name: concourse
+  stemcell: default
   jobs:
   - name: atc
     release: concourse
@@ -44,9 +47,7 @@ instance_groups:
 
 - name: worker
   instances: 1
-  azs: [az1]
-  networks:
-  - name: concourse
+  stemcell: default
   jobs:
   - release: concourse
     name: groundcrew

--- a/concourse.yml
+++ b/concourse.yml
@@ -4,23 +4,8 @@ name: concourse
 # Meta property overrides
 meta:
   environment: ~
-  az: ~
   atc:
     external_url: ~
-  network:
-    reserved: ~
-    dns: ~
-  resources:
-    web:
-      instance_type: ~
-      elbs: ~
-    workers:
-      instance_type: ~
-  compilation:
-    instance_type: ~
-    disk:
-      size: ~
-      type: ~
   riemann_emitter:
     host: ~
     port: 5555
@@ -30,17 +15,6 @@ meta:
 # replace with bosh status --uuid
 director_uuid: ~
 
-# replace all addresses with your VPC range
-#
-# e.g. X.X.0.2 -> 10.0.0.2
-networks:
-- name: concourse
-  type: manual
-  subnets:
-  - (( inline ))
-  - reserved: (( grab meta.network.reserved ))
-    dns: (( grab meta.network.dns ))
-
 releases:
 - {name: concourse, version: latest}
 - {name: garden-runc, version: latest}
@@ -49,8 +23,8 @@ releases:
 instance_groups:
 - name: web
   instances: 1
-  resource_pool: web
-  networks: [{name: concourse}]
+  networks:
+  - name: concourse
   jobs:
   - name: atc
     release: concourse
@@ -59,7 +33,6 @@ instance_groups:
       external_url: (( grab meta.atc.external_url ))
   - name: tsa
     release: concourse
-    properties: {}
   - name: riemann-emitter
     release: riemann
     properties:
@@ -70,8 +43,8 @@ instance_groups:
 
 - name: worker
   instances: 1
-  resource_pool: workers
-  networks: [{name: concourse}]
+  networks:
+  - name: concourse
   jobs:
   - release: concourse
     name: groundcrew
@@ -86,7 +59,6 @@ instance_groups:
       drain_timeout: 15m
   - release: concourse
     name: baggageclaim
-    properties: {}
   - release: garden-runc
     name: garden
     properties:
@@ -104,44 +76,6 @@ instance_groups:
         host: (( grab meta.riemann_emitter.host ))
         port: (( grab meta.riemann_emitter.port ))
         health: true
-
-resource_pools:
-- name: web
-  network: concourse
-  stemcell: &stemcell
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: latest
-  cloud_properties:
-    availability_zone: &az (( grab meta.az ))
-    instance_type: (( grab meta.resources.web.instance_type ))
-    ephemeral_disk:
-      size: 45000
-      type: gp2
-      encrypted: true
-
-- name: workers
-  network: concourse
-  stemcell: *stemcell
-  cloud_properties:
-    availability_zone: *az
-    instance_type: (( grab meta.resources.workers.instance_type ))
-    ephemeral_disk:
-      size: 300000
-      type: gp2
-      encrypted: true
-
-compilation:
-  workers: 3
-  network: concourse
-  reuse_compilation_vms: true
-  cloud_properties:
-    availability_zone: *az
-    instance_type: (( grab meta.compilation.instance_type ))
-    iam_instance_profile: (( grab terraform_outputs.bosh_compilation_profile ))
-    ephemeral_disk:
-      size: (( grab meta.compilation.disk.size ))
-      type: (( grab meta.compilation.disk.type ))
-      encrypted: true
 
 update:
   canaries: 1

--- a/concourse.yml
+++ b/concourse.yml
@@ -23,6 +23,7 @@ releases:
 instance_groups:
 - name: web
   instances: 1
+  azs: [az1]
   networks:
   - name: concourse
   jobs:
@@ -43,6 +44,7 @@ instance_groups:
 
 - name: worker
   instances: 1
+  azs: [az1]
   networks:
   - name: concourse
   jobs:

--- a/generate.sh
+++ b/generate.sh
@@ -23,6 +23,7 @@ fi
 
 spruce merge --prune meta --prune terraform_outputs \
   $SCRIPTPATH/concourse.yml \
+  $SCRIPTPATH/rds-ca-cert.yml \
   $CONFIG \
   $SECRETS \
   $TERRAFORM \

--- a/rds-ca-cert.yml
+++ b/rds-ca-cert.yml
@@ -1,0 +1,53 @@
+instance_groups:
+- name: web
+  jobs:
+  - name: atc
+    properties:
+      postgresql:
+        # The following is the root and govcloud intermediate certs found
+        # at http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
+        ca_cert: |
+          -----BEGIN CERTIFICATE-----
+          MIID9DCCAtygAwIBAgIBQjANBgkqhkiG9w0BAQUFADCBijELMAkGA1UEBhMCVVMx
+          EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoM
+          GUFtYXpvbiBXZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMx
+          GzAZBgNVBAMMEkFtYXpvbiBSRFMgUm9vdCBDQTAeFw0xNTAyMDUwOTExMzFaFw0y
+          MDAzMDUwOTExMzFaMIGKMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3Rv
+          bjEQMA4GA1UEBwwHU2VhdHRsZTEiMCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNl
+          cywgSW5jLjETMBEGA1UECwwKQW1hem9uIFJEUzEbMBkGA1UEAwwSQW1hem9uIFJE
+          UyBSb290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuD8nrZ8V
+          u+VA8yVlUipCZIKPTDcOILYpUe8Tct0YeQQr0uyl018StdBsa3CjBgvwpDRq1HgF
+          Ji2N3+39+shCNspQeE6aYU+BHXhKhIIStt3r7gl/4NqYiDDMWKHxHq0nsGDFfArf
+          AOcjZdJagOMqb3fF46flc8k2E7THTm9Sz4L7RY1WdABMuurpICLFE3oHcGdapOb9
+          T53pQR+xpHW9atkcf3pf7gbO0rlKVSIoUenBlZipUlp1VZl/OD/E+TtRhDDNdI2J
+          P/DSMM3aEsq6ZQkfbz/Ilml+Lx3tJYXUDmp+ZjzMPLk/+3beT8EhrwtcG3VPpvwp
+          BIOqsqVVTvw/CwIDAQABo2MwYTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUw
+          AwEB/zAdBgNVHQ4EFgQUTgLurD72FchM7Sz1BcGPnIQISYMwHwYDVR0jBBgwFoAU
+          TgLurD72FchM7Sz1BcGPnIQISYMwDQYJKoZIhvcNAQEFBQADggEBAHZcgIio8pAm
+          MjHD5cl6wKjXxScXKtXygWH2BoDMYBJF9yfyKO2jEFxYKbHePpnXB1R04zJSWAw5
+          2EUuDI1pSBh9BA82/5PkuNlNeSTB3dXDD2PEPdzVWbSKvUB8ZdooV+2vngL0Zm4r
+          47QPyd18yPHrRIbtBtHR/6CwKevLZ394zgExqhnekYKIqqEX41xsUV0Gm6x4vpjf
+          2u6O/+YE2U+qyyxHE5Wd5oqde0oo9UUpFETJPVb6Q2cEeQib8PBAyi0i6KnF+kIV
+          A9dY7IHSubtCK/i8wxMVqfd5GtbA8mmpeJFwnDvm9rBEsHybl08qlax9syEwsUYr
+          /40NawZfTUU=
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          MIIDQzCCAqygAwIBAgIJAMGs6m/j+u8sMA0GCSqGSIb3DQEBBQUAMHUxCzAJBgNV
+          BAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTZWF0dGxlMRMw
+          EQYDVQQKEwpBbWF6b24uY29tMQwwCgYDVQQLEwNSRFMxHDAaBgNVBAMTE2F3cy5h
+          bWF6b24uY29tL3Jkcy8wHhcNMTIwODE2MDY0MjAwWhcNMTcwODE1MDY0MjAwWjB1
+          MQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2Vh
+          dHRsZTETMBEGA1UEChMKQW1hem9uLmNvbTEMMAoGA1UECxMDUkRTMRwwGgYDVQQD
+          ExNhd3MuYW1hem9uLmNvbS9yZHMvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
+          gQCnTB7AkRR4xuhfAuOt5foNeCRBPeUujkzmJu1yfnTbtFi+g7zmovQ9BJcRoPYL
+          45McnXyaT/7UjhJhCI5gnYlTIyBTRFh7lXFJryypFx8AIh6q3D/ht8b6cVro3sJ2
+          k4x1w/c7akKKsZJtf0ZyhbMvNnBz3K3TWVB6c9DChbfyUQIDAQABo4HaMIHXMB0G
+          A1UdDgQWBBS/OwyfNJHDnAmnZBbq9ACiXz7O1jCBpwYDVR0jBIGfMIGcgBS/Owyf
+          NJHDnAmnZBbq9ACiXz7O1qF5pHcwdTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldh
+          c2hpbmd0b24xEDAOBgNVBAcTB1NlYXR0bGUxEzARBgNVBAoTCkFtYXpvbi5jb20x
+          DDAKBgNVBAsTA1JEUzEcMBoGA1UEAxMTYXdzLmFtYXpvbi5jb20vcmRzL4IJAMGs
+          6m/j+u8sMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEACR37LqHlzjSH
+          9gHCaiVJgCb0CCxSg3PHaQuv8h4ugAqQpGxpX3Zo97VgHnjEve21gXA74kzGUUAo
+          7YNTZWbF2VkHUDqekXimvL3q1JEvHDKPkLJrxEic1zTU1uazb9uJeb1aVWTq6N8R
+          bx56xd/e3o7RYcPfLD45y7RRXKz3AmE=
+          -----END CERTIFICATE-----


### PR DESCRIPTION
Temporarily copy deprecated config into tenant concourse until staging
and production bosh are updated to use cloud config.

Goes with https://github.com/18F/cg-deploy-bosh/pull/73