### PR TITLE
Move environment config for tenant concourse out of secrets

### DIFF
--- a/concourse-tenant-production.yml
+++ b/concourse-tenant-production.yml
@@ -1,0 +1,10 @@
+instance_groups:
+- name: web
+  instances: 2
+  jobs:
+  - name: atc
+    properties:
+      external_url: https://concourse-ci.fr.cloud.gov
+
+- name: worker
+  instances: 3

--- a/concourse-tenant-staging.yml
+++ b/concourse-tenant-staging.yml
@@ -1,0 +1,6 @@
+instance_groups:
+- name: web
+  jobs:
+  - name: atc
+    properties:
+      external_url: https://concourse-ci.fr-stage.cloud.gov

--- a/concourse-tenant.yml
+++ b/concourse-tenant.yml
@@ -19,7 +19,8 @@ instance_groups:
       riemann_emitter:
         rds:
           instance_name: (( grab terraform_outputs.concourse_rds_identifier ))
-          region: (( grab meta.rds.region ))
+          region: (( grab terraform_outputs.vpc_region ))
+
 - name: worker
   vm_type: concourse-worker
   azs: [z2]

--- a/concourse.yml
+++ b/concourse.yml
@@ -1,19 +1,7 @@
 ---
 name: concourse
 
-# Meta property overrides
-meta:
-  environment: ~
-  atc:
-    external_url: ~
-  riemann_emitter:
-    host: ~
-    port: 5555
-  rds:
-    region: ~
-
-# replace with bosh status --uuid
-director_uuid: ~
+director_uuid: (( param "specify director UUID"))
 
 releases:
 - {name: concourse, version: latest}
@@ -33,8 +21,11 @@ instance_groups:
   - name: atc
     release: concourse
     properties:
+      riemann:
+        host: (( grab meta.riemann_emitter.host ))
+        service_prefix: concourse.
       web_bind_port: 8080
-      external_url: (( grab meta.atc.external_url ))
+      external_url: (( param "specify external url" ))
   - name: tsa
     release: concourse
   - name: riemann-emitter

--- a/generate.sh
+++ b/generate.sh
@@ -4,27 +4,8 @@ set -e -x
 
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 
-CONFIG=""
-SECRETS=$SCRIPTPATH/secrets.yml
-TERRAFORM=$SCRIPTPATH/terraform.yml
-MANIFEST=$SCRIPTPATH/manifest.yml
-if [ ! -z "$1" ]; then
-  CONFIG=$1
-fi
-if [ ! -z "$2" ]; then
-  SECRETS=$2
-fi
-if [ ! -z "$3" ]; then
-  TERRAFORM=$3
-fi
-if [ ! -z "$4" ]; then
-  MANIFEST=$4
-fi
-
 spruce merge --prune meta --prune terraform_outputs \
   $SCRIPTPATH/concourse.yml \
   $SCRIPTPATH/rds-ca-cert.yml \
-  $CONFIG \
-  $SECRETS \
-  $TERRAFORM \
-  > $MANIFEST
+  $@ \
+> concourse-manifest/manifest.yml

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
       - name: common
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-staging.yml", "common/secrets.yml", "terraform-yaml/state.yml", "concourse-manifest/manifest.yml"]
+        args: ["concourse-config/concourse-staging.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
       outputs:
       - name: concourse-manifest
   - put: ops-concourse-staging-deployment
@@ -91,7 +91,7 @@ jobs:
       <<: *manifest-config
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml", "concourse-manifest/manifest.yml"]
+        args: ["concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
   - put: ops-concourse-production-deployment
     params: *deploy-params
   on_failure:
@@ -137,7 +137,7 @@ jobs:
       <<: *manifest-config
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-tenant.yml", "common/secrets.yml", "terraform-yaml/state.yml", "concourse-manifest/manifest.yml"]
+        args: ["concourse-config/concourse-tenant.yml", "common/secrets.yml", "concourse-config/concourse-tenant-staging.yml", terraform-yaml/state.yml"]
   - put: tenant-concourse-staging-deployment
     params: *deploy-params
   on_failure:
@@ -187,7 +187,7 @@ jobs:
       <<: *manifest-config
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-tenant.yml", "common/secrets.yml", "terraform-yaml/state.yml", "concourse-manifest/manifest.yml"]
+        args: ["concourse-config/concourse-tenant.yml", "common/secrets.yml", "concourse-config/concourse-tenant-production.yml", "terraform-yaml/state.yml"]
   - put: tenant-concourse-production-deployment
     params: *deploy-params
   on_failure:


### PR DESCRIPTION
This produces the same manifest that are currently deployed, the env specific configuration is just moved out of secrets.