### PR TITLE
Clean up iaas worker definition.

### DIFF
--- a/concourse-ops.yml
+++ b/concourse-ops.yml
@@ -1,0 +1,13 @@
+instance_groups:
+- name: iaas-worker
+  inject: (( inject instance_groups.worker ))
+  vm_extensions: nil
+  jobs:
+  - name: groundcrew
+    properties:
+      team: main
+      tags:
+      - iaas
+    consumes: {baggageclaim: {from: iaas-baggageclaim}}
+  - name: baggageclaim
+    provides: {baggageclaim: {as: iaas-baggageclaim}}

--- a/concourse-production.yml
+++ b/concourse-production.yml
@@ -22,16 +22,18 @@ instance_groups:
         rds:
           instance_name: (( grab terraform_outputs.production_concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
+
 - name: worker
   vm_type: production-concourse-worker
   vm_extensions: [production-concourse-profile]
   azs: [z1]
   networks:
   - name: production-concourse
+
 - name: iaas-worker
   vm_type: production-concourse-iaas-worker
-  vm_extensions: [production-concourse-iaas-profile]
+  vm_extensions: (( grab meta.iaas_extensions ))
   instances: 2
-  azs: [z1]
-  networks:
-  - name: production-concourse
+
+meta:
+  iaas_extensions: [production-concourse-iaas-profile]

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -20,16 +20,18 @@ instance_groups:
         rds:
           instance_name: (( grab terraform_outputs.staging_concourse_rds_identifier ))
           region: (( grab meta.rds.region ))
+
 - name: worker
   vm_type: staging-concourse-worker
   vm_extensions: [staging-concourse-profile]
   azs: [z2]
   networks:
   - name: staging-concourse
+
 - name: iaas-worker
   vm_type: staging-concourse-iaas-worker
-  vm_extensions: [staging-concourse-iaas-profile]
-  instances: 2
-  azs: [z2]
-  networks:
-  - name: staging-concourse
+  vm_extensions: (( grab meta.iaas_extensions ))
+  instances: 1
+
+meta:
+  iaas_extensions: [staging-concourse-iaas-profile]

--- a/concourse.yml
+++ b/concourse.yml
@@ -70,43 +70,6 @@ instance_groups:
         port: (( grab meta.riemann_emitter.port ))
         health: true
 
-- name: iaas-worker
-  stemcell: default
-  instances: 0
-  jobs:
-  - name: groundcrew
-    release: concourse
-    properties:
-      additional_resource_types:
-      - type: slack-notification
-        image: docker:///cfcommunity/slack-notification-resource
-      - type: cg-common
-        image: docker:///18fgsa/cg-common-resource
-      - type: 18f-bosh-deployment
-        image: docker:///18fgsa/bosh-deployment-resource
-      drain_timeout: 15m
-      team: main
-      tags:
-      - iaas
-    consumes: {baggageclaim: {from: iaas-baggageclaim}}
-  - name: baggageclaim
-    release: concourse
-    provides: {baggageclaim: {as: iaas-baggageclaim}}
-  - name: garden
-    release: garden-runc
-    properties:
-      garden:
-        listen_network: tcp
-        listen_address: 0.0.0.0:7777
-        graph_cleanup_threshold_in_mb: 2048
-  - name: riemann-emitter
-    release: riemann
-    properties:
-      riemann_emitter:
-        host: (( grab meta.riemann_emitter.host ))
-        port: (( grab meta.riemann_emitter.port ))
-        health: true
-
 update:
   canaries: 1
   max_in_flight: 1

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
       - name: common
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-staging.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
+        args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-staging.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
       outputs:
       - name: concourse-manifest
   - put: ops-concourse-staging-deployment
@@ -91,7 +91,7 @@ jobs:
       <<: *manifest-config
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
+        args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
   - put: ops-concourse-production-deployment
     params: *deploy-params
   on_failure:


### PR DESCRIPTION
So that we duplicate less configuration from the standard worker, and so that tenant concourse never sees the iaas worker instance group.