### PR TITLE
Drop riemann rds emitter.

### DIFF
--- a/concourse-production.yml
+++ b/concourse-production.yml
@@ -14,12 +14,6 @@ instance_groups:
         role:
           name: (( grab terraform_outputs.production_concourse_rds_username ))
           password: (( grab terraform_outputs.production_concourse_rds_password ))
-  - name: riemann-emitter
-    properties:
-      riemann_emitter:
-        rds:
-          instance_name: (( grab terraform_outputs.production_concourse_rds_identifier ))
-          region: (( grab meta.rds.region ))
 
 - name: worker
   vm_type: production-concourse-worker

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -14,12 +14,6 @@ instance_groups:
         role:
           name: (( grab terraform_outputs.staging_concourse_rds_username ))
           password: (( grab terraform_outputs.staging_concourse_rds_password ))
-  - name: riemann-emitter
-    properties:
-      riemann_emitter:
-        rds:
-          instance_name: (( grab terraform_outputs.staging_concourse_rds_identifier ))
-          region: (( grab meta.rds.region ))
 
 - name: worker
   vm_type: staging-concourse-worker

--- a/concourse-tenant.yml
+++ b/concourse-tenant.yml
@@ -14,12 +14,6 @@ instance_groups:
         role:
           name: (( grab terraform_outputs.concourse_rds_username ))
           password: (( grab terraform_outputs.concourse_rds_password ))
-  - name: riemann-emitter
-    properties:
-      riemann_emitter:
-        rds:
-          instance_name: (( grab terraform_outputs.concourse_rds_identifier ))
-          region: (( grab terraform_outputs.vpc_region ))
 
 - name: worker
   vm_type: concourse-worker

--- a/concourse.yml
+++ b/concourse.yml
@@ -6,7 +6,6 @@ director_uuid: (( param "specify director UUID"))
 releases:
 - {name: concourse, version: latest}
 - {name: garden-runc, version: latest}
-- {name: riemann, version: latest}
 
 stemcells:
 - alias: default
@@ -28,13 +27,6 @@ instance_groups:
       external_url: (( param "specify external url" ))
   - name: tsa
     release: concourse
-  - name: riemann-emitter
-    release: riemann
-    properties:
-      riemann_emitter:
-        host: (( grab meta.riemann_emitter.host ))
-        port: (( grab meta.riemann_emitter.port ))
-        health: true
 
 - name: worker
   instances: 1
@@ -62,13 +54,6 @@ instance_groups:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
         graph_cleanup_threshold_in_mb: 2048
-  - name: riemann-emitter
-    release: riemann
-    properties:
-      riemann_emitter:
-        host: (( grab meta.riemann_emitter.host ))
-        port: (( grab meta.riemann_emitter.port ))
-        health: true
 
 update:
   canaries: 1


### PR DESCRIPTION
The riemann rds emitter is constantly failing with permission errors in all environments. Since we're planning to drop riemann soon, let's drop this emitter now instead of fixing it.