### PR TITLE
Restrict tenant concourse containers to public networks.

### DIFF
--- a/concourse-tenant.yml
+++ b/concourse-tenant.yml
@@ -26,3 +26,14 @@ instance_groups:
   azs: [z2]
   networks:
   - name: concourse
+  jobs:
+  - name: garden
+    properties:
+      garden:
+        deny_networks:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        dns_servers:
+        - 8.8.8.8
+        - 8.8.4.4


### PR DESCRIPTION
https://www.youtube.com/watch?v=AaFamedaS1g

Where "Riverdale" means "private network".