### PR TITLE
Generate certificates with bosh-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This repo contains the pipeline and [BOSH](https://bosh.io) manifests for deploy
 
 ## Generating certificates
 
-```sh
-bosh interpolate certs.yml --vars-store vars.yml > certs-interpolated.yml
-```
+* Generate certificates using bosh `variables`
+
+    ```sh
+    bosh interpolate certs.yml --vars-store vars.yml > certs-interpolated.yml
+    ```
+
+* Merge credentials into existing secrets
+
+    ```sh
+    spruce merge secrets.yml certs-interpolated.yml > secrets-complete.yml
+    ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # 18F Concourse deployment
 
 This repo contains the pipeline and [BOSH](https://bosh.io) manifests for deploying [Concourse](https://concourse.ci/) tasks.
+
+## Generating certificates
+
+```sh
+bosh interpolate certs.yml --vars-store vars.yml > certs-interpolated.yml
+```

--- a/certs.yml
+++ b/certs.yml
@@ -1,0 +1,29 @@
+---
+instance_groups:
+- name: web
+  jobs:
+  - name: atc
+    properties:
+      token_signing_key: ((token_signing_key))
+  - name: tsa
+    properties:
+      log_level: debug
+      host_key: ((tsa_host_key))
+      token_signing_key: ((token_signing_key))
+      authorized_keys:
+      - ((worker_key.public_key))
+
+- name: worker
+  jobs:
+  - name: groundcrew
+    properties:
+      tsa:
+        worker_key: ((worker_key))
+
+variables:
+- name: token_signing_key
+  type: rsa
+- name: tsa_host_key
+  type: ssh
+- name: worker_key
+  type: ssh

--- a/concourse.yml
+++ b/concourse.yml
@@ -20,9 +20,9 @@ instance_groups:
   - name: atc
     release: concourse
     properties:
-      riemann:
-        host: (( grab meta.riemann_emitter.host ))
-        service_prefix: concourse.
+      prometheus:
+        bind_ip: 0.0.0.0
+        bind_port: 9110
       web_bind_port: 8080
       external_url: (( param "specify external url" ))
   - name: tsa


### PR DESCRIPTION
Adapted from
https://github.com/concourse/concourse-deployment/blob/master/cluster/concourse.yml.

To generate staging secrets, I ran `bosh interpolate` and `spruce merge`-d the result with the existing secrets.