### PR TITLE
Prune stalled workers after tenant deploy.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -144,6 +144,12 @@ jobs:
   - *lint-manifest
   - put: tenant-concourse-staging-deployment
     params: *deploy-params
+  - task: prune-stalled-workers
+    file: concourse-config/ci/prune-stalled-workers.yml
+    params:
+      CONCOURSE_URL: https://concourse-ci.fr-stage.cloud.gov
+      CONCOURSE_USERNAME: {{tenant-concourse-username-staging}}
+      CONCOURSE_PASSWORD: {{tenant-concourse-password-staging}}
   on_failure:
     put: slack
     params:
@@ -194,6 +200,12 @@ jobs:
   - *lint-manifest
   - put: tenant-concourse-production-deployment
     params: *deploy-params
+  - task: prune-stalled-workers
+    file: concourse-config/ci/prune-stalled-workers.yml
+    params:
+      CONCOURSE_URL: https://concourse-ci.fr.cloud.gov
+      CONCOURSE_USERNAME: {{tenant-concourse-username-production}}
+      CONCOURSE_PASSWORD: {{tenant-concourse-password-production}}
   on_failure:
     put: slack
     params:
@@ -223,6 +235,7 @@ resources:
     - concourse*.yml
     - rds*.yml
     - generate.sh
+    - ci/*
 
 - name: pipeline-tasks
   type: git

--- a/ci/prune-stalled-workers.sh
+++ b/ci/prune-stalled-workers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eux
+
+curl -o fly "${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=linux"
+chmod +x ./fly
+fly="./fly"
+
+${fly} -t ci login -c "${CONCOURSE_URL}" -u "${CONCOURSE_USERNAME}" -p "${CONCOURSE_PASSWORD}"
+
+for worker in $(${fly} -t ci workers | grep stalled | awk '{print $1}'); do
+  ${fly} -t ci prune-worker -w "${worker}"
+done

--- a/ci/prune-stalled-workers.yml
+++ b/ci/prune-stalled-workers.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: 18fgsa/concourse-task
+
+inputs:
+- {name: concourse-config}
+
+run:
+  path: concourse-config/ci/prune-stalled-workers.sh


### PR DESCRIPTION
This is a hack that we should drop as soon as https://github.com/concourse/concourse/issues/1497 is resolved. Note: we're only using basic auth for tenant concourse, so this script doesn't run on ops concourse.