### PR TITLE
Add basic smoke test against staging.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,6 +48,12 @@ jobs:
       - garden-runc-release/*.tgz
       stemcells:
       - concourse-stemcell/*.tgz
+  - task: smoke-test
+    file: concourse-config/ci/smoke-test.yml
+    params:
+      ATC_URL: http://0.web.staging-concourse.concourse-staging.toolingbosh:8080
+      BASIC_AUTH_USERNAME: {{basic-auth-username-staging}}
+      BASIC_AUTH_PASSWORD: {{basic-auth-password-staging}}
   on_failure:
     put: slack
     params:

--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eux
+
+curl -o fly "${ATC_URL}/api/v1/cli?arch=amd64&platform=linux"
+chmod +x ./fly
+
+(
+  set +x
+  ./fly --target ci login \
+    --concourse-url "${ATC_URL}" \
+    --username "${BASIC_AUTH_USERNAME}" \
+    --password "${BASIC_AUTH_PASSWORD}"
+)
+
+cat > config.yml << EOF
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: busybox
+
+run:
+  path: echo
+  args: ["smoke"]
+EOF
+
+output=$(./fly --target ci execute --config ./config.yml)
+
+if ! echo "${output}" | grep smoke; then
+  echo "Expected to find `smoke` in output"
+  exit 1
+fi

--- a/ci/smoke-test.yml
+++ b/ci/smoke-test.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: 18fgsa/concourse-task
+
+inputs:
+- name: concourse-config
+
+run:
+  path: concourse-config/ci/smoke-test.sh

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -8,6 +8,8 @@ instance_groups:
   jobs:
   - name: atc
     properties:
+      basic_auth_username: (( param "specify basic auth username" ))
+      basic_auth_password: (( param "specify basic auth password" ))
       postgresql:
         database: (( grab terraform_outputs.staging_concourse_rds_name ))
         host: (( grab terraform_outputs.staging_concourse_rds_host ))


### PR DESCRIPTION
After deploying staging, run a test task with `fly execute` to verify that the atc is scheduling containers and workers are running tasks. If something big breaks (for example, the database configuration gets screwed up, or a new stemcell breaks garden), we won't roll out the change to production.