### PR TITLE
Check in non-sensitive concourse defaults.

### DIFF
--- a/ci/concourse-defaults.yml
+++ b/ci/concourse-defaults.yml
@@ -4,6 +4,7 @@ concourse-config-git-url: https://github.com/18F/cg-deploy-concourse.git
 pipeline-tasks-git-branch: master
 pipeline-tasks-git-url: https://github.com/18F/cg-pipeline-tasks.git
 
+tf-state-bucket: terraform-state
 tf-state-file: tooling/state.yml
 
 concourse-staging-deployment-bosh-deployment: concourse-staging
@@ -18,3 +19,4 @@ aws-region: us-gov-west-1
 concourse-production-deployment-bosh-uaa-client-id: ci
 concourse-staging-deployment-bosh-uaa-client-id: ci
 
+secrets-bucket: cloud-gov-varz

--- a/ci/concourse-defaults.yml
+++ b/ci/concourse-defaults.yml
@@ -4,7 +4,7 @@ concourse-config-git-url: https://github.com/18F/cg-deploy-concourse.git
 pipeline-tasks-git-branch: master
 pipeline-tasks-git-url: https://github.com/18F/cg-pipeline-tasks.git
 
-tf-state-file-tooling: tooling/state.yml
+tf-state-file: tooling/state.yml
 
 concourse-staging-deployment-bosh-deployment: concourse-staging
 concourse-production-deployment-bosh-deployment: concourse-production
@@ -12,3 +12,9 @@ concourse-production-deployment-bosh-deployment: concourse-production
 slack-channel: "#cg-platform"
 slack-icon-url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
 slack-username: concourse
+
+aws-region: us-gov-west-1
+
+concourse-production-deployment-bosh-uaa-client-id: ci
+concourse-staging-deployment-bosh-uaa-client-id: ci
+

--- a/ci/concourse-defaults.yml
+++ b/ci/concourse-defaults.yml
@@ -1,0 +1,14 @@
+concourse-config-git-branch: master
+concourse-config-git-url: https://github.com/18F/cg-deploy-concourse.git
+
+pipeline-tasks-git-branch: master
+pipeline-tasks-git-url: https://github.com/18F/cg-pipeline-tasks.git
+
+tf-state-file-tooling: tooling/state.yml
+
+concourse-staging-deployment-bosh-deployment: concourse-staging
+concourse-production-deployment-bosh-deployment: concourse-production
+
+slack-channel: "#cg-platform"
+slack-icon-url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+slack-username: concourse

--- a/ci/pipeline-development.yml
+++ b/ci/pipeline-development.yml
@@ -96,6 +96,7 @@ resources:
   type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version_family: 3468.latest
 
 - name: concourse-release
   type: bosh-io-release

--- a/ci/pipeline-development.yml
+++ b/ci/pipeline-development.yml
@@ -30,7 +30,7 @@ jobs:
       - name: common
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
+        args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-development.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
       outputs:
       - name: concourse-manifest
   - &lint-manifest

--- a/ci/pipeline-development.yml
+++ b/ci/pipeline-development.yml
@@ -91,7 +91,6 @@ resources:
     region: ((aws-region))
     secrets_file: concourse-tooling-prod.yml
     secrets_passphrase: ((concourse-production-private-passphrase))
-    bosh_cert: bosh-tooling.pem
 
 - name: concourse-stemcell
   type: bosh-io-stemcell

--- a/ci/pipeline-development.yml
+++ b/ci/pipeline-development.yml
@@ -87,7 +87,7 @@ resources:
 - name: common-production
   type: cg-common
   source:
-    bucket_name: ((concourse-production-private-bucket))
+    bucket_name: ((secrets-bucket))
     region: ((aws-region))
     secrets_file: concourse-tooling-prod.yml
     secrets_passphrase: ((concourse-production-private-passphrase))

--- a/ci/pipeline-development.yml
+++ b/ci/pipeline-development.yml
@@ -1,16 +1,16 @@
 ---
 jobs:
-- name: deploy-concourse-staging
+- name: deploy-concourse-production
   serial: true
   plan:
   - aggregate:
     - get: concourse-config
       trigger: true
     - get: pipeline-tasks
-    - get: common
-      resource: common-staging
-      trigger: true
     - get: terraform-yaml
+    - get: common
+      resource: common-production
+      trigger: true
     - get: concourse-stemcell
       trigger: true
     - get: concourse-release
@@ -30,7 +30,7 @@ jobs:
       - name: common
       run:
         path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-staging.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
+        args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
       outputs:
       - name: concourse-manifest
   - &lint-manifest
@@ -39,7 +39,7 @@ jobs:
     input_mapping:
       pipeline-config: concourse-config
       lint-manifest: concourse-manifest
-  - put: concourse-staging-deployment
+  - put: concourse-production-deployment
     params: &deploy-params
       manifest: concourse-manifest/manifest.yml
       releases:
@@ -47,17 +47,11 @@ jobs:
       - garden-runc-release/*.tgz
       stemcells:
       - concourse-stemcell/*.tgz
-  - task: smoke-test
-    file: concourse-config/ci/smoke-test.yml
-    params:
-      ATC_URL: http://0.web.staging-concourse.concourse-staging.toolingbosh:8080
-      BASIC_AUTH_USERNAME: ((basic-auth-username-staging))
-      BASIC_AUTH_PASSWORD: ((basic-auth-password-staging))
   on_failure:
     put: slack
     params:
       text: |
-        :x: FAILED to deploy Concourse on staging
+        :x: FAILED to deploy DEV Concourse on production
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))
@@ -66,56 +60,7 @@ jobs:
     put: slack
     params:
       text: |
-        :white_check_mark: Successfully deployed Concourse on staging
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: deploy-concourse-production
-  serial: true
-  plan:
-  - aggregate:
-    - get: concourse-config
-      passed: [deploy-concourse-staging]
-      trigger: true
-    - get: pipeline-tasks
-    - get: terraform-yaml
-    - get: common
-      resource: common-production
-      trigger: true
-    - get: concourse-stemcell
-      trigger: true
-      passed: [deploy-concourse-staging]
-    - get: concourse-release
-      trigger: true
-      passed: [deploy-concourse-staging]
-    - get: garden-runc-release
-      trigger: false
-      passed: [deploy-concourse-staging]
-  - task: concourse-manifest
-    config:
-      <<: *manifest-config
-      run:
-        path: concourse-config/generate.sh
-        args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
-  - *lint-manifest
-  - put: concourse-production-deployment
-    params: *deploy-params
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy Concourse on production
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed Concourse on production
+        :white_check_mark: Successfully deployed DEV Concourse on production
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))
@@ -148,15 +93,6 @@ resources:
     secrets_passphrase: ((concourse-production-private-passphrase))
     bosh_cert: bosh-tooling.pem
 
-- name: common-staging
-  type: cg-common
-  source:
-    bucket_name: ((concourse-staging-private-bucket))
-    region: ((aws-region))
-    secrets_file: concourse-tooling-staging.yml
-    secrets_passphrase: ((concourse-staging-private-passphrase))
-    bosh_cert: bosh-tooling.pem
-
 - name: concourse-stemcell
   type: bosh-io-stemcell
   source:
@@ -179,15 +115,6 @@ resources:
     client: ci
     client_secret: ((tooling_bosh_uaa_ci_client_secret))
     deployment: ((concourse-production-deployment-bosh-deployment))
-    ca_cert: ((common_ca_cert_store))
-
-- name: concourse-staging-deployment
-  type: bosh-deployment
-  source:
-    target: ((concourse-staging-deployment-bosh-target))
-    client: ci
-    client_secret: ((tooling_bosh_uaa_ci_client_secret))
-    deployment: ((concourse-staging-deployment-bosh-deployment))
     ca_cert: ((common_ca_cert_store))
 
 - name: slack

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -142,7 +142,7 @@ resources:
 - name: common-production
   type: cg-common
   source:
-    bucket_name: ((concourse-production-private-bucket))
+    bucket_name: ((secrets-bucket))
     region: ((aws-region))
     secrets_file: concourse-tooling-prod.yml
     secrets_passphrase: ((concourse-production-private-passphrase))
@@ -150,7 +150,7 @@ resources:
 - name: common-staging
   type: cg-common
   source:
-    bucket_name: ((concourse-staging-private-bucket))
+    bucket_name: ((secrets-bucket))
     region: ((aws-region))
     secrets_file: concourse-tooling-staging.yml
     secrets_passphrase: ((concourse-staging-private-passphrase))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,6 +1,6 @@
 ---
 jobs:
-- name: deploy-ops-concourse-staging
+- name: deploy-concourse-staging
   serial: true
   plan:
   - aggregate:
@@ -8,10 +8,9 @@ jobs:
       trigger: true
     - get: pipeline-tasks
     - get: common
-      resource: common-ops-staging
+      resource: common-staging
       trigger: true
     - get: terraform-yaml
-      resource: terraform-yaml-tooling
     - get: concourse-stemcell
       trigger: true
     - get: concourse-release
@@ -40,7 +39,7 @@ jobs:
     input_mapping:
       pipeline-config: concourse-config
       lint-manifest: concourse-manifest
-  - put: ops-concourse-staging-deployment
+  - put: concourse-staging-deployment
     params: &deploy-params
       manifest: concourse-manifest/manifest.yml
       releases:
@@ -73,28 +72,27 @@ jobs:
       username: {{slack-username}}
       icon_url: {{slack-icon-url}}
 
-- name: deploy-ops-concourse-production
+- name: deploy-concourse-production
   serial: true
   plan:
   - aggregate:
     - get: concourse-config
-      passed: [deploy-ops-concourse-staging]
+      passed: [deploy-concourse-staging]
       trigger: true
     - get: pipeline-tasks
     - get: terraform-yaml
-      resource: terraform-yaml-tooling
     - get: common
-      resource: common-ops-production
+      resource: common-production
       trigger: true
     - get: concourse-stemcell
       trigger: true
-      passed: [deploy-ops-concourse-staging]
+      passed: [deploy-concourse-staging]
     - get: concourse-release
       trigger: true
-      passed: [deploy-ops-concourse-staging]
+      passed: [deploy-concourse-staging]
     - get: garden-runc-release
       trigger: false
-      passed: [deploy-ops-concourse-staging]
+      passed: [deploy-concourse-staging]
   - task: concourse-manifest
     config:
       <<: *manifest-config
@@ -102,7 +100,7 @@ jobs:
         path: concourse-config/generate.sh
         args: ["concourse-config/concourse-ops.yml", "concourse-config/concourse-production.yml", "common/secrets.yml", "terraform-yaml/state.yml"]
   - *lint-manifest
-  - put: ops-concourse-production-deployment
+  - put: concourse-production-deployment
     params: *deploy-params
   on_failure:
     put: slack
@@ -141,22 +139,22 @@ resources:
     uri: {{pipeline-tasks-git-url}}
     branch: {{pipeline-tasks-git-branch}}
 
-- name: common-ops-production
+- name: common-production
   type: cg-common
   source:
-    bucket_name: {{ops-concourse-production-private-bucket}}
+    bucket_name: {{concourse-production-private-bucket}}
     region: {{aws-region}}
     secrets_file: concourse-tooling-prod.yml
-    secrets_passphrase: {{ops-concourse-production-private-passphrase}}
+    secrets_passphrase: {{concourse-production-private-passphrase}}
     bosh_cert: bosh-tooling.pem
 
-- name: common-ops-staging
+- name: common-staging
   type: cg-common
   source:
-    bucket_name: {{ops-concourse-staging-private-bucket}}
+    bucket_name: {{concourse-staging-private-bucket}}
     region: {{aws-region}}
     secrets_file: concourse-tooling-staging.yml
-    secrets_passphrase: {{ops-concourse-staging-private-passphrase}}
+    secrets_passphrase: {{concourse-staging-private-passphrase}}
     bosh_cert: bosh-tooling.pem
 
 - name: concourse-stemcell
@@ -174,30 +172,30 @@ resources:
   source:
     repository: cloudfoundry/garden-runc-release
 
-- name: ops-concourse-production-deployment
+- name: concourse-production-deployment
   type: bosh-deployment
   source:
-    target: {{ops-concourse-production-deployment-bosh-target}}
-    client: {{ops-concourse-production-deployment-bosh-uaa-client-id}}
-    client_secret: {{ops-concourse-production-deployment-bosh-uaa-client-secret}}
-    deployment: {{ops-concourse-production-deployment-bosh-deployment}}
-    ca_cert: {{ops-concourse-production-bosh-ca-cert}}
+    target: {{concourse-production-deployment-bosh-target}}
+    client: {{concourse-production-deployment-bosh-uaa-client-id}}
+    client_secret: {{concourse-production-deployment-bosh-uaa-client-secret}}
+    deployment: {{concourse-production-deployment-bosh-deployment}}
+    ca_cert: {{concourse-production-bosh-ca-cert}}
 
-- name: ops-concourse-staging-deployment
+- name: concourse-staging-deployment
   type: bosh-deployment
   source:
-    target: {{ops-concourse-staging-deployment-bosh-target}}
-    client: {{ops-concourse-staging-deployment-bosh-uaa-client-id}}
-    client_secret: {{ops-concourse-staging-deployment-bosh-uaa-client-secret}}
-    deployment: {{ops-concourse-staging-deployment-bosh-deployment}}
-    ca_cert: {{ops-concourse-staging-bosh-ca-cert}}
+    target: {{concourse-staging-deployment-bosh-target}}
+    client: {{concourse-staging-deployment-bosh-uaa-client-id}}
+    client_secret: {{concourse-staging-deployment-bosh-uaa-client-secret}}
+    deployment: {{concourse-staging-deployment-bosh-deployment}}
+    ca_cert: {{concourse-staging-bosh-ca-cert}}
 
 - name: slack
   type: slack-notification-docker
   source:
     url: {{slack-webhook-url}}
 
-- name: terraform-yaml-tooling
+- name: terraform-yaml
   type: s3-iam
   source:
     bucket: {{tf-state-bucket-tooling}}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -146,7 +146,6 @@ resources:
     region: ((aws-region))
     secrets_file: concourse-tooling-prod.yml
     secrets_passphrase: ((concourse-production-private-passphrase))
-    bosh_cert: bosh-tooling.pem
 
 - name: common-staging
   type: cg-common
@@ -155,7 +154,6 @@ resources:
     region: ((aws-region))
     secrets_file: concourse-tooling-staging.yml
     secrets_passphrase: ((concourse-staging-private-passphrase))
-    bosh_cert: bosh-tooling.pem
 
 - name: concourse-stemcell
   type: bosh-io-stemcell

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -159,6 +159,7 @@ resources:
   type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version_family: 3468.latest
 
 - name: concourse-release
   type: bosh-io-release

--- a/concourse-development.yml
+++ b/concourse-development.yml
@@ -1,0 +1,30 @@
+instance_groups:
+- name: web
+  instances: 1
+  vm_type: production-concourse-web
+  vm_extensions: [production-concourse-lb]
+  azs: [z1]
+  networks:
+  - name: production-concourse
+  jobs:
+  - name: atc
+    properties:
+      postgresql:
+        database: (( grab terraform_outputs.production_concourse_rds_name ))
+        host: (( grab terraform_outputs.production_concourse_rds_host ))
+        role:
+          name: (( grab terraform_outputs.production_concourse_rds_username ))
+          password: (( grab terraform_outputs.production_concourse_rds_password ))
+
+- name: worker
+  instances: 1
+  vm_type: production-concourse-worker
+  vm_extensions: [production-concourse-profile]
+  azs: [z1]
+  networks:
+  - name: production-concourse
+
+- name: iaas-worker
+  vm_type: production-concourse-iaas-worker
+  vm_extensions: [production-concourse-iaas-profile]
+  instances: 1

--- a/concourse-production.yml
+++ b/concourse-production.yml
@@ -25,8 +25,5 @@ instance_groups:
 
 - name: iaas-worker
   vm_type: production-concourse-iaas-worker
-  vm_extensions: (( grab meta.iaas_extensions ))
+  vm_extensions: [production-concourse-iaas-profile]
   instances: 2
-
-meta:
-  iaas_extensions: [production-concourse-iaas-profile]

--- a/concourse-staging.yml
+++ b/concourse-staging.yml
@@ -27,8 +27,5 @@ instance_groups:
 
 - name: iaas-worker
   vm_type: staging-concourse-iaas-worker
-  vm_extensions: (( grab meta.iaas_extensions ))
+  vm_extensions: [staging-concourse-iaas-profile]
   instances: 1
-
-meta:
-  iaas_extensions: [staging-concourse-iaas-profile]

--- a/concourse.yml
+++ b/concourse.yml
@@ -1,8 +1,6 @@
 ---
 name: concourse
 
-director_uuid: (( param "specify director UUID"))
-
 releases:
 - {name: concourse, version: latest}
 - {name: garden-runc, version: latest}


### PR DESCRIPTION
And drop the `ops-` prefix, which we don't need anymore now that all concourses are part of ops.