### PR TITLE
set version_family to 3468.latest on concourse stemcell resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -163,6 +163,7 @@ resources:
   type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version_family: 3468.latest
 
 - name: concourse-release
   type: bosh-io-release


### PR DESCRIPTION
Because concourse currently has issues with 3541.x