### PR TITLE
Updates for concourse 3.10.

### DIFF
--- a/certs.yml
+++ b/certs.yml
@@ -15,7 +15,7 @@ instance_groups:
 
 - name: worker
   jobs:
-  - name: groundcrew
+  - name: worker
     properties:
       tsa:
         worker_key: ((worker_key))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -159,7 +159,6 @@ resources:
   type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version_family: 3468.latest
 
 - name: concourse-release
   type: bosh-io-release

--- a/concourse-ops.yml
+++ b/concourse-ops.yml
@@ -3,11 +3,10 @@ instance_groups:
   inject: (( inject instance_groups.worker ))
   vm_extensions: nil
   jobs:
-  - name: groundcrew
+  - name: worker
     properties:
       team: main
-      tags:
-      - iaas
+      tags: [iaas]
     consumes: {baggageclaim: {from: iaas-baggageclaim}}
   - name: baggageclaim
     provides: {baggageclaim: {as: iaas-baggageclaim}}

--- a/concourse.yml
+++ b/concourse.yml
@@ -31,7 +31,7 @@ instance_groups:
   instances: 1
   stemcell: default
   jobs:
-  - name: groundcrew
+  - name: worker
     release: concourse
     properties:
       additional_resource_types:
@@ -46,6 +46,8 @@ instance_groups:
   - name: baggageclaim
     release: concourse
     provides: {baggageclaim: {as: default-baggageclaim}}
+    properties:
+      driver: overlay
   - name: garden
     release: garden-runc
     properties:


### PR DESCRIPTION
* Rename groundcrew to worker
* Continue using overlay driver
* Switch to latest stemcell series

Note: concourse 3.10 switches from overlay back to btrfs. I'm suggesting with stick with overlay for another few releases in case there are lingering stability issues.