### PR TITLE
Add build log retention to production.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -85,6 +85,7 @@ jobs:
       ops_files:
       - concourse-deployment/cluster/operations/external-postgres.yml
       - concourse-deployment/cluster/operations/external-postgres-tls.yml
+      - concourse-deployment/cluster/operations/build-log-retention.yml
       - concourse-deployment/cluster/operations/scale.yml
       - concourse-config/operations/iaas-worker.yml
       - concourse-config/operations/latest-stemcell.yml


### PR DESCRIPTION
Forgot that staging and prod have different opsfile lists 😓 