### PR TITLE
CredHub for development jumpboxes

### DIFF
--- a/shell-pipeline.yml
+++ b/shell-pipeline.yml
@@ -31,10 +31,6 @@ jobs:
       BOSH_CLIENT: {{staging-bosh-client}}
       BOSH_CLIENT_SECRET: {{staging-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CLIENT: ((stagingbosh/credhub-admin-client))
-      CREDHUB_SECRET: ((stagingbosh/credhub-admin-secret))
-      CREDHUB_SERVER: ((stagingbosh/credhub-api-server))
       PROMPT_COLOR: "2" # green
 
 - name: container-bosh-production
@@ -48,10 +44,6 @@ jobs:
       BOSH_CLIENT: {{production-bosh-client}}
       BOSH_CLIENT_SECRET: {{production-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CLIENT: ((productionbosh/credhub-admin-client))
-      CREDHUB_SECRET: ((productionbosh/credhub-admin-secret))
-      CREDHUB_SERVER: ((productionbosh/credhub-api-server))
       PROMPT_COLOR: "1" # red
 
 - name: container-bosh-tooling
@@ -65,10 +57,6 @@ jobs:
       BOSH_CLIENT: {{tooling-bosh-uaa-client}}
       BOSH_CLIENT_SECRET: {{tooling-bosh-uaa-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CLIENT: ((toolingbosh/credhub-admin-client))
-      CREDHUB_SECRET: ((toolingbosh/credhub-admin-secret))
-      CREDHUB_SERVER: ((toolingbosh/credhub-api-server))
       PROMPT_COLOR: "3" # yellow
 
 - name: container-bosh-master
@@ -82,10 +70,6 @@ jobs:
       BOSH_CLIENT: {{master-bosh-client}}
       BOSH_CLIENT_SECRET: {{master-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CLIENT: ((masterbosh/credhub-admin-client))
-      CREDHUB_SECRET: ((masterbosh/credhub-admin-secret))
-      CREDHUB_SERVER: ((masterbosh/credhub-api-server))
       PROMPT_COLOR: "5" # magenta
 
 resources:

--- a/shell-pipeline.yml
+++ b/shell-pipeline.yml
@@ -15,9 +15,9 @@ jobs:
       BOSH_CLIENT_SECRET: {{development-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
       CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      CREDHUB_CLIENT: ((developmentbosh/credhub-admin-client))
-      CREDHUB_SECRET: ((developmentbosh/credhub-admin-secret))
-      CREDHUB_SERVER: ((developmentbosh/credhub-api-server))
+      CREDHUB_CLIENT: {{development-credhub-admin-client}}
+      CREDHUB_SECRET: {{development-credhub-admin-secret}}
+      CREDHUB_SERVER: {{development-credhub-api-server}}
       PROMPT_COLOR: "6" # cyan
 
 - name: container-bosh-staging

--- a/shell-pipeline.yml
+++ b/shell-pipeline.yml
@@ -14,6 +14,10 @@ jobs:
       BOSH_CLIENT: {{development-bosh-client}}
       BOSH_CLIENT_SECRET: {{development-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CLIENT: ((developmentbosh/credhub-admin-client))
+      CREDHUB_SECRET: ((developmentbosh/credhub-admin-secret))
+      CREDHUB_SERVER: ((developmentbosh/credhub-api-server))
       PROMPT_COLOR: "6" # cyan
 
 - name: container-bosh-staging
@@ -27,6 +31,10 @@ jobs:
       BOSH_CLIENT: {{staging-bosh-client}}
       BOSH_CLIENT_SECRET: {{staging-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CLIENT: ((stagingbosh/credhub-admin-client))
+      CREDHUB_SECRET: ((stagingbosh/credhub-admin-secret))
+      CREDHUB_SERVER: ((stagingbosh/credhub-api-server))
       PROMPT_COLOR: "2" # green
 
 - name: container-bosh-production
@@ -40,6 +48,10 @@ jobs:
       BOSH_CLIENT: {{production-bosh-client}}
       BOSH_CLIENT_SECRET: {{production-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CLIENT: ((productionbosh/credhub-admin-client))
+      CREDHUB_SECRET: ((productionbosh/credhub-admin-secret))
+      CREDHUB_SERVER: ((productionbosh/credhub-api-server))
       PROMPT_COLOR: "1" # red
 
 - name: container-bosh-tooling
@@ -53,6 +65,10 @@ jobs:
       BOSH_CLIENT: {{tooling-bosh-uaa-client}}
       BOSH_CLIENT_SECRET: {{tooling-bosh-uaa-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CLIENT: ((toolingbosh/credhub-admin-client))
+      CREDHUB_SECRET: ((toolingbosh/credhub-admin-secret))
+      CREDHUB_SERVER: ((toolingbosh/credhub-api-server))
       PROMPT_COLOR: "3" # yellow
 
 - name: container-bosh-master
@@ -66,6 +82,10 @@ jobs:
       BOSH_CLIENT: {{master-bosh-client}}
       BOSH_CLIENT_SECRET: {{master-bosh-client-secret}}
       BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CLIENT: ((masterbosh/credhub-admin-client))
+      CREDHUB_SECRET: ((masterbosh/credhub-admin-secret))
+      CREDHUB_SERVER: ((masterbosh/credhub-api-server))
       PROMPT_COLOR: "5" # magenta
 
 resources:


### PR DESCRIPTION
~~This work won't currently work as these variables aren't in CredHub yet~~
~~with the right values. But eventually, we should have them in there in~~
~~our co-located BOSH / Concourse CredHub and be able to pull them in~~
~~here.~~

Let's just stick the credentials where we need them. These came from the manifest for BOSH development. This will allow operators to leverage the `credhub-cli` from any Development jumpbox.