### PR TITLE
[WIP] Continue using trusty stemcell for now.

### DIFF
--- a/operations/generic-oauth.yml
+++ b/operations/generic-oauth.yml
@@ -3,9 +3,12 @@
   value:
     auth_url: https://opslogin.fr.cloud.gov/oauth/authorize
     token_url: https://opsuaa.fr.cloud.gov/oauth/token
+    userinfo_url: https://opsuaa.fr.cloud.gov/userinfo
+    scopes: [openid, concourse.admin]
+    groups_key: scope
     client_id: ((generic_oauth_client_id))
     client_secret: ((generic_oauth_client_secret))
-    auth_url_params:
-    - scope: openid,concourse.admin
-    scope: concourse.admin
-    display_name: UAA
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/oauth/groups
+  value: [concourse.admin]

--- a/operations/latest-stemcell.yml
+++ b/operations/latest-stemcell.yml
@@ -1,3 +1,21 @@
+- type: remove
+  path: /stemcells/alias=xenial
+
 - type: replace
-  path: /stemcells/alias=trusty/version
-  value: latest
+  path: /stemcells/-
+  value:
+    alias: trusty
+    os: ubuntu-trusty
+    version: latest
+
+- type: replace
+  path: /instance_groups/name=web/stemcell
+  value: trusty
+
+- type: replace
+  path: /instance_groups/name=worker/stemcell
+  value: trusty
+
+- type: replace
+  path: /instance_groups/name=iaas-worker/stemcell
+  value: trusty


### PR DESCRIPTION
The latest release of concourse-bosh-deployment switched to the xenial stemcells. We haven't gone through hardening for xenial yet, so we'll switch back to trusty for now.