### PR TITLE
Match upstream config

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -24,6 +24,7 @@ jobs:
       - concourse-deployment/cluster/operations/external-postgres-tls.yml
       - concourse-deployment/cluster/operations/build-log-retention.yml
       - concourse-deployment/cluster/operations/scale.yml
+      - concourse-deployment/cluster/operations/debug-concourse.yml
       - concourse-config/operations/iaas-worker.yml
       - concourse-config/operations/latest-stemcell.yml
       - concourse-config/operations/postgres-staging.yml
@@ -132,6 +133,7 @@ jobs:
       - concourse-deployment/cluster/operations/external-postgres-tls.yml
       - concourse-deployment/cluster/operations/build-log-retention.yml
       - concourse-deployment/cluster/operations/scale.yml
+      - concourse-deployment/cluster/operations/debug-concourse.yml
       - concourse-config/operations/iaas-worker.yml
       - concourse-config/operations/latest-stemcell.yml
       - concourse-config/operations/postgres-production.yml


### PR DESCRIPTION
As of 4.2.2, properties for baggageclaim moved to ops file.