### PR TITLE
allow for self-deployment

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2,6 +2,7 @@
 jobs:
 - name: deploy-concourse-staging
   serial: true
+  interruptible: true
   plan:
   - in_parallel:
     - get: concourse-deployment
@@ -107,6 +108,7 @@ jobs:
 
 - name: deploy-concourse-production
   serial: true
+  interruptible: true
   plan:
   - in_parallel:
     - get: concourse-deployment


### PR DESCRIPTION
## Changes proposed in this pull request:
- leveraging [this bespoke feature](https://concourse-ci.org/jobs.html#job-interruptible) lets us do the thing we all expect when concourse is deploying.

## Security Considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>