### PR TITLE
add a couple workers for scale.

### DIFF
--- a/variables/production.yml
+++ b/variables/production.yml
@@ -9,7 +9,7 @@ worker_vm_extensions: [production-concourse-profile]
 iaas_worker_vm_extensions: [production-concourse-iaas-profile]
 network_name: production-concourse
 web_instances: 3
-worker_instances: 5
+worker_instances: 7
 iaas_worker_instances: 2
 build_logs_default: 25
 build_logs_maximum: 0


### PR DESCRIPTION
## Changes proposed in this pull request:
- scale up non-iaas workers by 2 as the container density is too high on the workers, `max containers reached` keeps getting hit.

## security considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>