### PR TITLE
add gc defaults to keep the platform usage lower overall.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,6 +31,7 @@ jobs:
       - concourse-config/operations/external-postgres-tls.yml
       - concourse-config/operations/prometheus.yml
       - concourse-config/operations/update-strategy.yml
+      - concourse-config/operations/set-garbage-collection.yml
       # - concourse-config/operations/staging-disk-size.yml
       vars_files:
       - concourse-deployment/versions.yml
@@ -137,6 +138,8 @@ jobs:
       - concourse-config/operations/generic-oauth.yml
       - concourse-config/operations/compliance.yml
       - concourse-config/operations/prometheus.yml
+      - concourse-config/operations/update-strategy.yml
+      - concourse-config/operations/set-garbage-collection.yml
       # - concourse-config/operations/production-disk-size.yml
       vars_files:
       - concourse-deployment/versions.yml

--- a/operations/set-garbage-collection.yml
+++ b/operations/set-garbage-collection.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/gc?/
+  value:
+    missing_grace_period: 30s
+    hijack_grace_period: 11m # (mxplusb): this should not kick you out but I'm not sure yet.
+    one_off_grace_period: 10s
+    check_recycle_period: 10s


### PR DESCRIPTION
## Changes proposed in this pull request:
- assign default gc values to clean up the >8800 active volumes...
- use `create-swap-delete` since it's much faster.

## security considerations
[Note the any security considerations here, or make note of why there are none]

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>