### PR TITLE
Rollback az2

### DIFF
--- a/variables/production.yml
+++ b/variables/production.yml
@@ -1,6 +1,6 @@
 deployment_name: concourse-production
 external_url: https://ci.fr.cloud.gov
-azs: [z1,z2]
+azs: [z1]
 web_vm_type: m6i.large.concourse.web
 worker_vm_type: m6i.xlarge.concourse.worker
 iaas_worker_vm_type: m6i.xlarge.concourse.worker

--- a/variables/staging.yml
+++ b/variables/staging.yml
@@ -1,7 +1,7 @@
 deployment_name: concourse-staging
 external_url: https://ci.fr-stage.cloud.gov
 credhub_url: https://credhub.fr-stage.cloud.gov
-azs: [z1,z2]
+azs: [z2]
 web_vm_type: t3.medium.concourse.web
 worker_vm_type: m6i.xlarge.concourse.worker
 iaas_worker_vm_type: m6i.xlarge.concourse.worker


### PR DESCRIPTION
## Changes proposed in this pull request:
- There are additional VPC peering requirements that needs more research, rolling this back to unblock stemcell upgrades
- https://github.com/cloud-gov/private/issues/2469
-

## security considerations
None, rolls back azs to configuration used for the last x years.
