### PR TITLE
fix iptables rules for v8 upgrade

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -229,10 +229,7 @@ jobs:
         args:
         - -exc
         - |
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT || true'"
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT || true'"
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT'"
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT'"
+          bosh ssh iaas-worker "sudo sh -c '/var/vcap/jobs/post-deploy-script/bin/post-deploy'"
           bosh ssh iaas-worker "sudo sh -c '/var/vcap/jobs/aide/bin/update-aide-db'"
 
   - task: iptables-worker-bosh-dns
@@ -259,10 +256,7 @@ jobs:
         args:
         - -exc
         - |
-          bosh ssh worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT || true'"
-          bosh ssh worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT || true'"
-          bosh ssh worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT'"
-          bosh ssh worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT'"
+          bosh ssh worker "sudo sh -c '/var/vcap/jobs/post-deploy-script/bin/post-deploy'"
           bosh ssh worker "sudo sh -c '/var/vcap/jobs/aide/bin/update-aide-db'"
 
 - name: plan-concourse-production

--- a/operations/iptables.yml
+++ b/operations/iptables.yml
@@ -6,10 +6,10 @@
     properties:
       script: |
         #!/bin/bash
-        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
-        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
-        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
-        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
+        iptables -I INPUT -p udp --dport 53 -d 169.254.0.2 -j ACCEPT 
+        iptables -I INPUT -p tcp --dport 53 -d 169.254.0.2 -j ACCEPT
+        iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+        iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
         /bin/true
 
 
@@ -21,12 +21,11 @@
     properties:
       script: |
         #!/bin/bash
-        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
-        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
-        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
-        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
+        iptables -I INPUT -p udp --dport 53 -d 169.254.0.2 -j ACCEPT 
+        iptables -I INPUT -p tcp --dport 53 -d 169.254.0.2 -j ACCEPT
+        iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+        iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
         /bin/true
-
 
 - type: replace
   path: /releases/-


### PR DESCRIPTION
## Changes proposed in this pull request:
- With v8 release some of the iptables rules for bosh-dns needed to be updated

## Notes
Since OS-CONF creates the post-deploy script, using that for timer concourse job to update iptables rather then multi-loops for each IPTables commands

## security considerations
n/a